### PR TITLE
ISO code of Czech rep patched

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ section#noscript-padding { padding-bottom: 52px; }
             <a href="?lang=nl">Nederlands</a>
             <a href="?lang=ru">русский</a>
             <a href="?lang=zh-cn">简体中文</a>
-            <a href="?lang=cz">Česky</a>
+            <a href="?lang=cs">Česky</a>
         </section>
         <h1><label id=header_title>Peercoin Proof-Of-Stake (POS) Calculator v0.0.1</label></h1>
     </header>
@@ -438,12 +438,12 @@ section#noscript-padding { padding-bottom: 52px; }
             "footer_peercointalk": "捐赠Peercointalk的项目",
             "footer_github": "在GitHub上完善这个项目吧"
         },
-        "cz": {
+        "cs": {
             "title": "Peercoin POS kalkulačka",
             "header_prefix": "Jazyky: ",
-            "header_title": "Peercoin potvrzení vlastnictvím=Proof-of-stake (POS) kalkulátor v0.0.1",
+            "header_title": "Peercoin potvrzování transakcí vlastnictvím = Proof-of-stake (POS) kalkulátor v0.0.1",
             "intro": "Aktuálně jsou zde pouze jednoduché funkce ale můžete:",
-            "desc1": "Zadej počet coinů, jež je v počítané transakci, počet dní které uběhly od obdržení transakce a POS obtížnost.",
+            "desc1": "Zadej počet coinů, které jsou v počítané transakci a počet dní které uběhly od obdržení transakce a POS obtížnost.",
             "desc2": "Pravděpodobnost mintování bloku dosáhne svého maxima po 90 dnech a poté se nezvyšuje.",
             "desc3": "První sloupec tabulky odměn ukazuje POS odměnu pro tebou zadané dny a po třicet dní (minimální počet dní k získání POS odměny).",
             "desc4": "Druhý sloupec tabulky odměn poté ukazuje POS odměnu (složený úrok) za mintování bloku 31 dní po prvním bloku (pokud jsi nepřesunul coiny a coiny získané POS).",


### PR DESCRIPTION
patched ISO code for czech republic. note, that CZ is ISO code for Czech Republic, and CS is ISO code for Czech language. Used CZ, because FuzzyBear wanted it.
